### PR TITLE
Add functionality to save game state to local storage

### DIFF
--- a/cmd/clicker/main.go
+++ b/cmd/clicker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/kmdkuk/clicker/config"
 	"github.com/kmdkuk/clicker/game"
@@ -17,7 +18,7 @@ func main() {
 	g := game.NewGame(cfg)
 	ebiten.SetWindowSize(800, 600)
 	ebiten.SetWindowTitle("Clicker")
-
+	g.StartAutoSave((30 * time.Second))
 	if err := ebiten.RunGame(g); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/clicker/main.go
+++ b/cmd/clicker/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kmdkuk/clicker/config"
 	"github.com/kmdkuk/clicker/game"
+	"golang.org/x/net/context"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	flag "github.com/spf13/pflag"
@@ -18,7 +19,11 @@ func main() {
 	g := game.NewGame(cfg)
 	ebiten.SetWindowSize(800, 600)
 	ebiten.SetWindowTitle("Clicker")
-	g.StartAutoSave((30 * time.Second))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g.StartAutoSave(ctx, 30*time.Second)
 	if err := ebiten.RunGame(g); err != nil {
 		log.Fatal(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,12 +1,18 @@
 package config
 
 type Config struct {
-	EnableDebug bool // Enable or disable debug mode
+	EnableDebug bool   // Enable or disable debug mode
+	SaveKey     string // Key for saving game state
 }
 
 // NewConfig creates a new configuration with default values
 func NewConfig() *Config {
 	return &Config{
 		EnableDebug: false, // Debug mode is disabled by default
+		SaveKey:     DefaultSaveKey,
 	}
 }
+
+const (
+	DefaultSaveKey string = "game_state.json"
+)

--- a/game/game.go
+++ b/game/game.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"image/color"
+	"log"
 	"time"
 
 	"github.com/kmdkuk/clicker/config"
@@ -19,25 +20,46 @@ type Game struct {
 	cursor       int             // Cursor position
 	page         int             // Page position
 	gameState    state.GameState // Game state
-	decider      input.Decider   // Decision maker
-	inputHandler input.Handler   // Handler to manage input processing
-	popup        ui.Popup        // Popup message
-	debugMessage string          // Debug message
+	storage      state.Storage
+	decider      input.Decider // Decision maker
+	inputHandler input.Handler // Handler to manage input processing
+	popup        ui.Popup      // Popup message
+	debugMessage string        // Debug message
 }
 
 func NewGame(config *config.Config) *Game {
-	gameState := state.NewGameState() // Initialize game state
+	storage := state.NewDefaultStorage(state.NewStorageDriver(config.SaveKey))
+
+	gameState, err := storage.LoadGameState()
+	if err != nil {
+		log.Printf("Failed to load game state: %v", err)
+		gameState = state.NewGameState()
+	}
+
 	game := &Game{
 		config:       config,
 		cursor:       0, // Initial cursor position
 		page:         0, // Initial page position,
 		gameState:    gameState,
+		storage:      storage,
 		decider:      input.NewDefaultDecider(gameState),
 		inputHandler: input.NewHandler(),
 		popup:        ui.Popup{Active: false, Message: ""},
 	}
 	game.validateCursorPosition()
 	return game
+}
+
+func (g *Game) StartAutoSave(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			err := g.storage.SaveGameState(g.gameState)
+			if err != nil {
+				log.Printf("Auto-save failed: %v", err)
+			}
+		}
+	}()
 }
 
 func (g *Game) Update() error {

--- a/game_state.json
+++ b/game_state.json
@@ -1,0 +1,1 @@
+{"Money":19.120496329570237,"Buildings":[1,0,0,0,0,0,0],"Upgradings":[false],"ManualWork":58}

--- a/input/decider.go
+++ b/input/decider.go
@@ -17,7 +17,7 @@ func NewDefaultDecider(gameState GameStateWriter) Decider {
 func (d *DefaultDecider) Decide(page, cursor int) (bool, string) {
 	// マニュアルワークの選択
 	if cursor == 0 {
-		d.gameState.ManualWork()
+		d.gameState.ManualWorkAction()
 		return true, ""
 	}
 

--- a/input/decider_test.go
+++ b/input/decider_test.go
@@ -42,7 +42,7 @@ func (m *MockGameState) GetUpgrades() []model.Upgrade {
 func (m *MockGameState) SetUpgrades(upgrades []model.Upgrade) {
 	m.upgrades = upgrades
 }
-func (m *MockGameState) ManualWork() {
+func (m *MockGameState) ManualWorkAction() {
 	m.manualWorkCalled = true
 	m.UpdateMoney(m.manualWork.Work(m.upgrades))
 }

--- a/input/game_state_writer.go
+++ b/input/game_state_writer.go
@@ -1,7 +1,7 @@
 package input
 
 type GameStateWriter interface {
-	ManualWork()
+	ManualWorkAction()
 	PurchaseBuildingAction(cursor int) (bool, string)
 	PurchaseUpgradeAction(cursor int) (bool, string)
 }

--- a/model/building.go
+++ b/model/building.go
@@ -7,10 +7,10 @@ import (
 
 type Building struct {
 	ID               int     // Unique identifier
-	Name             string  // Display name
-	BaseCost         float64 // Base cost to unlock
-	BaseGenerateRate float64 // Money generated per second
-	Count            int     // Number of purchases
+	Name             string  `json:"name"`
+	BaseCost         float64 `json:"base_cost"`
+	BaseGenerateRate float64 `json:"base_generate_rate"`
+	Count            int     `json:"count"`
 }
 
 // Cost method: Calculates the cost based on the current number of purchases

--- a/model/manual_work.go
+++ b/model/manual_work.go
@@ -1,9 +1,9 @@
 package model
 
 type ManualWork struct {
-	Name  string  // Display name
-	Value float64 // Money earned manually
-	Count int
+	Name  string  `json:"name"`  // Display name
+	Value float64 `json:"value"` // Money earned manually
+	Count int     `json:"count"`
 }
 
 func (m *ManualWork) String() string {

--- a/model/upgrade.go
+++ b/model/upgrade.go
@@ -5,13 +5,13 @@ import (
 )
 
 type Upgrade struct {
-	Name               string                     // Upgrade name
-	Cost               float64                    // Cost to purchase the upgrade
-	Effect             func(float64) float64      // Effect applied when the upgrade is purchased
-	IsPurchased        bool                       // Whether the upgrade has been purchased
-	IsTargetManualWork bool                       // Whether the upgrade is for manual work
-	TargetBuilding     int                        // Target building index (if applicable)
-	IsReleased         func(GameStateReader) bool // Whether the upgrade is released
+	Name               string                     `json:"name"`
+	Cost               float64                    `json:"cost"`
+	Effect             func(float64) float64      `json:"-"` // Exclude from JSON encoding
+	IsPurchased        bool                       `json:"is_purchased"`
+	IsTargetManualWork bool                       `json:"is_target_manual_work"`
+	TargetBuilding     int                        `json:"target_building"`
+	IsReleased         func(GameStateReader) bool `json:"-"` // Exclude from JSON encoding
 }
 
 func (u *Upgrade) String(g GameStateReader) string {

--- a/state/game_state.go
+++ b/state/game_state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kmdkuk/clicker/level"
@@ -8,74 +9,107 @@ import (
 )
 
 type GameState interface {
-	ManualWork()                                             // マニュアルワークを実行します
+	ManualWorkAction()                                       // マニュアルワークを実行します
 	UpdateMoney(amount float64)                              // お金を更新します
 	PurchaseBuildingAction(buildingIndex int) (bool, string) // 建物を購入します
 	PurchaseUpgradeAction(upgradeIndex int) (bool, string)   // アップグレードを購入します
 	GetTotalGenerateRate() float64                           // 総生成レートを取得します
 	UpdateBuildings(now time.Time)
 	GetBuildings() []model.Building
+	SetBuildingCount(buildingIndex int, count int) error
 	GetUpgrades() []model.Upgrade
 	SetUpgrades(upgrades []model.Upgrade)
+	SetUpgradesIsPurchased(upgradeIndex int, isPurchased bool) error
 	GetMoney() float64
 	GetManualWork() *model.ManualWork
+	SetManualWorkCount(count int) error
 }
 
 // GameState はゲームの状態を管理します
 type DefaultGameState struct {
-	money      float64
-	manualWork model.ManualWork
-	buildings  []model.Building
-	upgrades   []model.Upgrade
-	lastUpdate time.Time
+	Money      float64          `json:"money"`
+	ManualWork model.ManualWork `json:"manual_work"`
+	Buildings  []model.Building `json:"buildings"`
+	Upgrades   []model.Upgrade  `json:"upgrades"`
+	LastUpdate time.Time        `json:"last_update"`
 }
 
 func NewGameState() GameState {
 	return &DefaultGameState{
-		money:      0,
-		manualWork: model.ManualWork{Name: "Manual Work: $0.1", Value: 0.1, Count: 0},
-		buildings:  level.NewBuildings(),
-		upgrades:   level.NewUpgrades(),
-		lastUpdate: time.Now(),
+		Money:      0,
+		ManualWork: model.ManualWork{Name: "Manual Work: $0.1", Value: 0.1, Count: 0},
+		Buildings:  level.NewBuildings(),
+		Upgrades:   level.NewUpgrades(),
+		LastUpdate: time.Now(),
 	}
 }
 
 func (g *DefaultGameState) GetBuildings() []model.Building {
-	return g.buildings
-}
-func (g *DefaultGameState) GetUpgrades() []model.Upgrade {
-	return g.upgrades
-}
-func (g *DefaultGameState) SetUpgrades(upgrades []model.Upgrade) {
-	g.upgrades = upgrades
-}
-func (g *DefaultGameState) GetMoney() float64 {
-	return g.money
-}
-func (g *DefaultGameState) GetManualWork() *model.ManualWork {
-	return &g.manualWork
-}
-func (g *DefaultGameState) SetManualWork(manualWork model.ManualWork) {
-	g.manualWork = manualWork
+	return g.Buildings
 }
 
-func (g *DefaultGameState) ManualWork() {
-	g.UpdateMoney(g.manualWork.Work(g.upgrades))
+func (g *DefaultGameState) SetBuildingCount(buildingIndex int, count int) error {
+	if buildingIndex < 0 || buildingIndex >= len(g.Buildings) {
+		return fmt.Errorf("invalid building index: %d", buildingIndex)
+	}
+	if count < 0 {
+		return fmt.Errorf("invalid building count: %d", count)
+	}
+	g.Buildings[buildingIndex].Count = count
+	return nil
+}
+
+func (g *DefaultGameState) GetUpgrades() []model.Upgrade {
+	return g.Upgrades
+}
+
+func (g *DefaultGameState) SetUpgrades(upgrades []model.Upgrade) {
+	g.Upgrades = upgrades
+}
+
+func (g *DefaultGameState) SetUpgradesIsPurchased(upgradeIndex int, isPurchased bool) error {
+	if upgradeIndex < 0 || upgradeIndex >= len(g.Upgrades) {
+		return fmt.Errorf("invalid upgrade index: %d", upgradeIndex)
+	}
+	g.Upgrades[upgradeIndex].IsPurchased = isPurchased
+	return nil
+}
+
+func (g *DefaultGameState) GetMoney() float64 {
+	return g.Money
+}
+func (g *DefaultGameState) GetManualWork() *model.ManualWork {
+	return &g.ManualWork
+}
+func (g *DefaultGameState) SetManualWork(manualWork model.ManualWork) {
+	g.ManualWork = manualWork
+}
+
+func (g *DefaultGameState) SetManualWorkCount(count int) error {
+	if count < 0 {
+		return fmt.Errorf("invalid manual work count: %d", count)
+	}
+	g.ManualWork.Count = count
+	return nil
+}
+
+func (g *DefaultGameState) ManualWorkAction() {
+	g.UpdateMoney(g.ManualWork.Work(g.Upgrades))
 }
 
 func (g *DefaultGameState) UpdateMoney(amount float64) {
-	g.money += amount
+	g.Money += amount
 }
 
 func (g *DefaultGameState) PurchaseBuildingAction(buildingIndex int) (bool, string) {
-	if buildingIndex < 0 || buildingIndex >= len(g.buildings) {
+	if buildingIndex < 0 || buildingIndex >= len(g.Buildings) {
 		return false, "Invalid building selection!"
 	}
 
-	building := &g.buildings[buildingIndex]
+	building := &g.Buildings[buildingIndex]
 	cost := building.Cost()
 
-	if g.money < cost {
+	if g.Money < cost {
 		if building.IsUnlocked() {
 			return false, "Not enough money to purchase!"
 		}
@@ -89,11 +123,11 @@ func (g *DefaultGameState) PurchaseBuildingAction(buildingIndex int) (bool, stri
 
 // PurchaseUpgradeAction はアップグレードの購入を試みて結果を返します
 func (g *DefaultGameState) PurchaseUpgradeAction(upgradeIndex int) (bool, string) {
-	if upgradeIndex < 0 || upgradeIndex >= len(g.upgrades) {
+	if upgradeIndex < 0 || upgradeIndex >= len(g.Upgrades) {
 		return false, "Invalid upgrade selection!"
 	}
 
-	upgrade := &g.upgrades[upgradeIndex]
+	upgrade := &g.Upgrades[upgradeIndex]
 
 	if upgrade.IsPurchased {
 		return false, "Upgrade already purchased!"
@@ -103,7 +137,7 @@ func (g *DefaultGameState) PurchaseUpgradeAction(upgradeIndex int) (bool, string
 		return false, "Upgrade not available yet!"
 	}
 
-	if g.money < upgrade.Cost {
+	if g.Money < upgrade.Cost {
 		return false, "Not enough money for upgrade!"
 	}
 
@@ -114,21 +148,21 @@ func (g *DefaultGameState) PurchaseUpgradeAction(upgradeIndex int) (bool, string
 
 func (g *DefaultGameState) GetTotalGenerateRate() float64 {
 	totalRate := 0.0
-	for _, building := range g.buildings {
+	for _, building := range g.Buildings {
 		if building.IsUnlocked() {
-			totalRate += building.TotalGenerateRate(g.upgrades)
+			totalRate += building.TotalGenerateRate(g.Upgrades)
 		}
 	}
 	return totalRate
 }
 
 func (g *DefaultGameState) UpdateBuildings(now time.Time) {
-	elapsed := now.Sub(g.lastUpdate).Seconds()
-	g.lastUpdate = now
+	elapsed := now.Sub(g.LastUpdate).Seconds()
+	g.LastUpdate = now
 
-	for _, building := range g.buildings {
+	for _, building := range g.Buildings {
 		if building.IsUnlocked() {
-			g.UpdateMoney(building.GenerateIncome(elapsed, g.upgrades))
+			g.UpdateMoney(building.GenerateIncome(elapsed, g.Upgrades))
 		}
 	}
 }

--- a/state/game_state_test.go
+++ b/state/game_state_test.go
@@ -15,11 +15,11 @@ var _ = Describe("DefaultGameState", func() {
 
 	BeforeEach(func() {
 		gameState = DefaultGameState{
-			money:      0,
-			manualWork: model.ManualWork{Name: "Manual Work: $0.1", Value: 0.1, Count: 0},
-			buildings:  level.NewBuildings(),
-			upgrades:   level.NewUpgrades(),
-			lastUpdate: time.Now(),
+			Money:      0,
+			ManualWork: model.ManualWork{Name: "Manual Work: $0.1", Value: 0.1, Count: 0},
+			Buildings:  level.NewBuildings(),
+			Upgrades:   level.NewUpgrades(),
+			LastUpdate: time.Now(),
 		} // Update to use gameState
 	})
 
@@ -39,16 +39,16 @@ var _ = Describe("DefaultGameState", func() {
 	Describe("updateBuildings", func() {
 		It("should generate income from unlocked buildings", func() {
 			now := time.Now()
-			gameState.buildings[0].Count = 1                 // Unlock the first building
-			gameState.lastUpdate = now.Add(-1 * time.Second) // Simulate 1 second elapsed
+			gameState.Buildings[0].Count = 1                 // Unlock the first building
+			gameState.LastUpdate = now.Add(-1 * time.Second) // Simulate 1 second elapsed
 
 			gameState.UpdateBuildings(now)
-			Expect(gameState.GetMoney()).To(Equal(gameState.buildings[0].BaseGenerateRate))
+			Expect(gameState.GetMoney()).To(Equal(gameState.Buildings[0].BaseGenerateRate))
 		})
 
 		It("should not generate income from locked buildings", func() {
 			now := time.Now()
-			gameState.lastUpdate = now.Add(-1 * time.Second) // Simulate 1 second elapsed
+			gameState.LastUpdate = now.Add(-1 * time.Second) // Simulate 1 second elapsed
 
 			gameState.UpdateBuildings(now)
 			Expect(gameState.GetMoney()).To(Equal(0.0))
@@ -57,10 +57,10 @@ var _ = Describe("DefaultGameState", func() {
 
 	Describe("GetTotalGenerateRate", func() {
 		It("should calculate the total generate rate from all unlocked buildings", func() {
-			gameState.buildings[0].Count = 1
-			gameState.buildings[1].Count = 2
+			gameState.Buildings[0].Count = 1
+			gameState.Buildings[1].Count = 2
 
-			expectedRate := gameState.buildings[0].BaseGenerateRate*1 + gameState.buildings[1].BaseGenerateRate*2
+			expectedRate := gameState.Buildings[0].BaseGenerateRate*1 + gameState.Buildings[1].BaseGenerateRate*2
 			Expect(gameState.GetTotalGenerateRate()).To(BeNumerically("~", expectedRate, 0.00001))
 		})
 
@@ -75,7 +75,7 @@ var _ = Describe("DefaultGameState", func() {
 			success, message := gameState.PurchaseBuildingAction(0)
 			Expect(success).To(BeTrue())
 			Expect(message).To(Equal("Building purchased successfully!"))
-			Expect(gameState.buildings[0].Count).To(Equal(1))
+			Expect(gameState.Buildings[0].Count).To(Equal(1))
 		})
 
 		It("should fail to purchase a building if not enough money", func() {
@@ -93,18 +93,18 @@ var _ = Describe("DefaultGameState", func() {
 
 	Describe("PurchaseUpgradeAction", func() {
 		It("should successfully purchase an upgrade", func() {
-			gameState.upgrades[0].IsReleased = func(g model.GameStateReader) bool {
+			gameState.Upgrades[0].IsReleased = func(g model.GameStateReader) bool {
 				return true
 			}
 			gameState.UpdateMoney(10.0) // Add enough money to purchase
 			success, message := gameState.PurchaseUpgradeAction(0)
 			Expect(success).To(BeTrue())
 			Expect(message).To(Equal("Upgrade purchased successfully!"))
-			Expect(gameState.upgrades[0].IsPurchased).To(BeTrue())
+			Expect(gameState.Upgrades[0].IsPurchased).To(BeTrue())
 		})
 
 		It("should fail to purchase an upgrade if not enough money", func() {
-			gameState.upgrades[0].IsReleased = func(g model.GameStateReader) bool {
+			gameState.Upgrades[0].IsReleased = func(g model.GameStateReader) bool {
 				return true
 			}
 			success, message := gameState.PurchaseUpgradeAction(0)

--- a/state/save.go
+++ b/state/save.go
@@ -1,0 +1,69 @@
+package state
+
+import (
+	"errors"
+
+	"github.com/kmdkuk/clicker/level"
+)
+
+type Save struct {
+	Money      float64
+	Buildings  []int
+	Upgradings []bool
+	ManualWork int
+}
+
+func ConverToSave(gameState GameState) Save {
+	buildings := make([]int, len(gameState.GetBuildings()))
+	upgradings := make([]bool, len(gameState.GetUpgrades()))
+
+	for i, b := range gameState.GetBuildings() {
+		buildings[i] = b.Count
+	}
+
+	for i, u := range gameState.GetUpgrades() {
+		upgradings[i] = u.IsPurchased
+	}
+
+	return Save{
+		Money:      gameState.GetMoney(),
+		Buildings:  buildings,
+		Upgradings: upgradings,
+		ManualWork: gameState.GetManualWork().Count,
+	}
+}
+
+func (s *Save) ConvertToGameState() (GameState, error) {
+	gameState := NewGameState()
+	gameState.UpdateMoney(s.Money)
+	if err := gameState.SetManualWorkCount(s.ManualWork); err != nil {
+		return gameState, err
+	}
+	for i, b := range s.Buildings {
+		if err := gameState.SetBuildingCount(i, b); err != nil {
+			return gameState, err
+		}
+	}
+	for i, u := range s.Upgradings {
+		if err := gameState.SetUpgradesIsPurchased(i, u); err != nil {
+			return gameState, err
+		}
+	}
+	return gameState, nil
+}
+
+func (s *Save) Validation() error {
+	if s.Money < 0 {
+		return errors.New("invalid money value")
+	}
+	if len(s.Buildings) > len(level.NewBuildings()) {
+		return errors.New("invalid buildings count")
+	}
+	if len(s.Upgradings) > len(level.NewUpgrades()) {
+		return errors.New("invalid upgrades count")
+	}
+	if s.ManualWork < 0 {
+		return errors.New("invalid manual work value")
+	}
+	return nil
+}

--- a/state/save_test.go
+++ b/state/save_test.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Save", func() {
+	var save Save
+
+	BeforeEach(func() {
+		save = Save{
+			Money:      100.0,
+			Buildings:  []int{1, 2, 3},
+			Upgradings: []bool{true},
+			ManualWork: 10,
+		}
+	})
+
+	Describe("IsValid", func() {
+		It("should return true for a valid Save", func() {
+			Expect(save.Validation()).ToNot(HaveOccurred())
+		})
+
+		It("should return false if Money is negative", func() {
+			save.Money = -1
+			Expect(save.Validation()).To(HaveOccurred())
+		})
+
+		It("should return false if Buildings length is invalid", func() {
+			save.Buildings = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+			Expect(save.Validation()).To(HaveOccurred())
+		})
+
+		It("should return false if Upgradings length is invalid", func() {
+			save.Upgradings = []bool{true, false, true}
+			Expect(save.Validation()).To(HaveOccurred())
+		})
+
+		It("should return false if ManualWork is negative", func() {
+			save.ManualWork = -1
+			Expect(save.Validation()).To(HaveOccurred())
+		})
+	})
+
+	Describe("ConvertToGameState", func() {
+		It("should convert Save to GameState successfully", func() {
+			gameState, err := save.ConvertToGameState()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gameState.GetMoney()).To(Equal(save.Money))
+			Expect(gameState.GetManualWork().Count).To(Equal(save.ManualWork))
+			// 他のフィールドも必要に応じて検証
+		})
+
+		It("should return an error if setting ManualWork fails", func() {
+			save.ManualWork = -1 // 無効な値を設定
+			_, err := save.ConvertToGameState()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error if setting Buildings fails", func() {
+			save.Buildings = []int{-1} // 無効な値を設定
+			_, err := save.ConvertToGameState()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error if setting Upgradings fails", func() {
+			save.Upgradings = []bool{true, false, true, true} // 長さが不正
+			_, err := save.ConvertToGameState()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/state/stage.go
+++ b/state/stage.go
@@ -1,7 +1,0 @@
-package state
-
-// Planned Enhancements:
-// - Implement functionality to save the game state to a file or database.
-// - Implement functionality to load the game state from a saved file or database.
-// - Integrate saving and loading functionality with JavaScript local storage for persistence.
-// - Refer to issue tracker ID #123 for detailed requirements and design discussions.

--- a/state/storage.go
+++ b/state/storage.go
@@ -1,0 +1,46 @@
+package state
+
+import (
+	"encoding/json"
+)
+
+type Storage interface {
+	SaveGameState(state GameState) error
+	LoadGameState() (GameState, error)
+}
+
+type DefaultStorage struct {
+	storageDriver StorageDriver
+}
+
+func NewDefaultStorage(driver StorageDriver) Storage {
+	return &DefaultStorage{
+		storageDriver: driver,
+	}
+}
+
+func (s *DefaultStorage) SaveGameState(state GameState) error {
+	save := ConverToSave(state)
+	data, err := json.Marshal(save)
+	if err != nil {
+		return err
+	}
+	return s.storageDriver.SaveData(data)
+}
+
+func (s *DefaultStorage) LoadGameState() (GameState, error) {
+	data, err := s.storageDriver.LoadData()
+	if err != nil {
+		return &DefaultGameState{}, err
+	}
+	var save Save
+	if err := json.Unmarshal(data, &save); err != nil {
+		return &DefaultGameState{}, err
+	}
+
+	if err := save.Validation(); err != nil {
+		return &DefaultGameState{}, err
+	}
+
+	return save.ConvertToGameState()
+}

--- a/state/storage_driver.go
+++ b/state/storage_driver.go
@@ -1,0 +1,6 @@
+package state
+
+type StorageDriver interface {
+	SaveData(data []byte) error
+	LoadData() ([]byte, error)
+}

--- a/state/storage_driver_default.go
+++ b/state/storage_driver_default.go
@@ -1,0 +1,32 @@
+//go:build !js && !wasm
+// +build !js,!wasm
+
+package state
+
+import (
+	"os"
+)
+
+const defaultSaveFileName = "game_state.json"
+
+func NewStorageDriver(key string) StorageDriver {
+	if key == "" {
+		return &DefaultStorageDriver{
+			path: defaultSaveFileName,
+		}
+	}
+	return &DefaultStorageDriver{
+		path: key,
+	}
+}
+
+type DefaultStorageDriver struct {
+	path string
+}
+
+func (s *DefaultStorageDriver) SaveData(data []byte) error {
+	return os.WriteFile(s.path, data, 0644)
+}
+func (s *DefaultStorageDriver) LoadData() ([]byte, error) {
+	return os.ReadFile(s.path)
+}

--- a/state/storage_driver_default_test.go
+++ b/state/storage_driver_default_test.go
@@ -1,0 +1,94 @@
+//go:build !js && !wasm
+// +build !js,!wasm
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil || !os.IsNotExist(err)
+}
+
+var _ = Describe("StorageDriverDefault", func() {
+	var storageDriver StorageDriver
+	var testByte []byte
+
+	BeforeEach(func() {
+		// 一意のファイル名を生成
+		testDescription := CurrentSpecReport()
+		testFileName := fmt.Sprintf("%s.json", strings.ReplaceAll(testDescription.FullText(), " ", "_"))
+		storageDriver = NewStorageDriver(testFileName)
+		testByte = []byte("test")
+	})
+
+	AfterEach(func() {
+		// テスト終了後にファイルを削除
+		testDescription := CurrentSpecReport()
+		testFileName := fmt.Sprintf("%s.json", strings.ReplaceAll(testDescription.FullText(), " ", "_"))
+		if FileExists(testFileName) {
+			err := os.Remove(testFileName)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	Describe("SaveData and LoadData", func() {
+		It("should save and load the game state correctly", func() {
+			// Save the game state
+			err := storageDriver.SaveData(testByte)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Load the game state
+			loadedByte, err := storageDriver.LoadData()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(loadedByte).To(Equal(testByte))
+		})
+
+		It("should return an empty state if the save file does not exist", func() {
+			// Load the game state
+			loadedByte, err := storageDriver.LoadData()
+			Expect(err).To(HaveOccurred())
+			Expect(loadedByte).To(Equal([]byte{}))
+		})
+
+		It("should overwrite the existing save file when saving new data", func() {
+			// Save initial data
+			err := storageDriver.SaveData(testByte)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Save new data
+			newTestByte := []byte("new test")
+			err = storageDriver.SaveData(newTestByte)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Load the game state
+			loadedByte, err := storageDriver.LoadData()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(loadedByte).To(Equal(newTestByte))
+		})
+
+		It("should handle saving an empty byte slice", func() {
+			// Save empty data
+			err := storageDriver.SaveData([]byte{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Load the game state
+			loadedByte, err := storageDriver.LoadData()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(loadedByte).To(Equal([]byte{}))
+		})
+
+		It("should return an error when saving fails", func() {
+			storageDriver = NewStorageDriver("invalid_path/test_save_file.json")
+			err := storageDriver.SaveData([]byte("test"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/state/storage_driver_default_test.go
+++ b/state/storage_driver_default_test.go
@@ -55,7 +55,7 @@ var _ = Describe("StorageDriverDefault", func() {
 			// Load the game state
 			loadedByte, err := storageDriver.LoadData()
 			Expect(err).To(HaveOccurred())
-			Expect(loadedByte).To(Equal([]byte{}))
+			Expect(loadedByte).To(Equal([]byte{})) // Ensure LoadData returns an empty slice for missing files
 		})
 
 		It("should overwrite the existing save file when saving new data", func() {

--- a/state/storage_driver_default_test.go
+++ b/state/storage_driver_default_test.go
@@ -51,7 +51,7 @@ var _ = Describe("StorageDriverDefault", func() {
 			Expect(loadedByte).To(Equal(testByte))
 		})
 
-		It("should return an empty and error if the save file does not exist", func() {
+		It("should return an error and an empty slice if the save file does not exist", func() {
 			// Load the game state
 			loadedByte, err := storageDriver.LoadData()
 			Expect(err).To(HaveOccurred())

--- a/state/storage_driver_default_test.go
+++ b/state/storage_driver_default_test.go
@@ -51,7 +51,7 @@ var _ = Describe("StorageDriverDefault", func() {
 			Expect(loadedByte).To(Equal(testByte))
 		})
 
-		It("should return an empty state if the save file does not exist", func() {
+		It("should return an empty and error if the save file does not exist", func() {
 			// Load the game state
 			loadedByte, err := storageDriver.LoadData()
 			Expect(err).To(HaveOccurred())

--- a/state/storage_driver_wasm.go
+++ b/state/storage_driver_wasm.go
@@ -1,0 +1,47 @@
+//go:build js && wasm
+// +build js,wasm
+
+package state
+
+import (
+	"errors"
+	"syscall/js"
+)
+
+func NewStorageDriver(key string) StorageDriver {
+	if key == "" {
+		return &StorageWasm{
+			key: defaultSaveKey,
+		}
+	}
+	return &StorageWasm{
+		key: key,
+	}
+}
+
+type StorageWasm struct {
+	key string
+}
+
+const defaultSaveKey = "game_state.json"
+
+func (s *StorageWasm) SaveData(data []byte) error {
+	localStorage := js.Global().Get("localStorage")
+	if localStorage.IsUndefined() {
+		return errors.New("localStorage is not available")
+	}
+	localStorage.Call("setItem", s.key, string(data))
+	return nil
+}
+
+func (s *StorageWasm) LoadData() ([]byte, error) {
+	localStorage := js.Global().Get("localStorage")
+	if localStorage.IsUndefined() {
+		return nil, errors.New("localStorage is not available")
+	}
+	data := localStorage.Call("getItem", s.key)
+	if data.IsNull() || data.IsUndefined() {
+		return nil, nil // Return nil if no data is found.
+	}
+	return []byte(data.String()), nil
+}


### PR DESCRIPTION
This PR introduces the ability to save game state to local storage. The following changes were made:

- Added functionality to persist game state to local storage.
- Updated relevant methods in the `state` package to support saving and loading from local storage.
- Added unit tests to ensure the correctness of the new functionality.

This feature enhances the user experience by allowing game progress to be saved and restored seamlessly.