### PR TITLE
Add Tab Component for Page Navigation

### DIFF
--- a/ui/components/tab.go
+++ b/ui/components/tab.go
@@ -1,0 +1,49 @@
+package components
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// Tab represents a UI component that displays tabs for different pages
+type Tab struct {
+	titles     []string // Titles for each tab
+	activePage int      // Currently active page index
+	x, y       int      // Position of the tabs
+}
+
+// NewTab creates a new Tab component
+func NewTab(titles []string, defaultPage int, x, y int) *Tab {
+	return &Tab{
+		titles:     titles,
+		activePage: defaultPage,
+		x:          x,
+		y:          y,
+	}
+}
+
+// Draw renders the tabs on the screen
+func (t *Tab) Draw(screen *ebiten.Image) {
+	for i, title := range t.titles {
+		xPos := t.x + i*120 // Space tabs 120 pixels apart
+
+		// Highlight the active tab
+		if i == t.activePage {
+			ebitenutil.DebugPrintAt(screen, "[x] "+title, xPos, t.y)
+		} else {
+			ebitenutil.DebugPrintAt(screen, "[ ] "+title, xPos, t.y)
+		}
+	}
+}
+
+// SetActivePage changes the active page
+func (t *Tab) SetActivePage(page int) {
+	if page >= 0 && page < len(t.titles) {
+		t.activePage = page
+	}
+}
+
+// GetActivePage returns the currently active page index
+func (t *Tab) GetActivePage() int {
+	return t.activePage
+}

--- a/ui/components/tab_test.go
+++ b/ui/components/tab_test.go
@@ -1,0 +1,83 @@
+package components
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Tab Component", func() {
+	var tab *Tab
+
+	BeforeEach(func() {
+		// Initialize a tab with test data before each test
+		tab = NewTab([]string{"Buildings", "Upgrades"}, 0, 10, 20)
+	})
+
+	Context("initialization", func() {
+		It("should correctly initialize with provided values", func() {
+			Expect(tab.titles).To(Equal([]string{"Buildings", "Upgrades"}))
+			Expect(tab.activePage).To(Equal(0))
+			Expect(tab.x).To(Equal(10))
+			Expect(tab.y).To(Equal(20))
+		})
+
+		It("should support initialization with non-zero default page", func() {
+			customTab := NewTab([]string{"Tab1", "Tab2", "Tab3"}, 1, 5, 15)
+			Expect(customTab.activePage).To(Equal(1))
+		})
+	})
+
+	Context("page management", func() {
+		It("should get the active page correctly", func() {
+			Expect(tab.GetActivePage()).To(Equal(0))
+
+			tab.activePage = 1
+			Expect(tab.GetActivePage()).To(Equal(1))
+		})
+
+		It("should set the active page within valid range", func() {
+			tab.SetActivePage(1)
+			Expect(tab.activePage).To(Equal(1))
+
+			// Back to first page
+			tab.SetActivePage(0)
+			Expect(tab.activePage).To(Equal(0))
+		})
+
+		It("should ignore invalid page indices", func() {
+			// Try setting out of range index
+			tab.SetActivePage(2)                // Beyond the range of our test tabs
+			Expect(tab.activePage).To(Equal(0)) // Should remain unchanged
+
+			tab.SetActivePage(-1)
+			Expect(tab.activePage).To(Equal(0)) // Should remain unchanged
+		})
+	})
+
+	Context("drawing functionality", func() {
+		It("should not panic when drawing", func() {
+			// Just verify that Draw doesn't panic
+			// We can't easily test the actual drawing results
+			screen := ebiten.NewImage(320, 240)
+			Expect(func() { tab.Draw(screen) }).NotTo(Panic())
+		})
+
+		// Note: Testing the exact visual output would require more complex testing
+		// involving image comparison or mocking the ebitenutil.DebugPrintAt function
+	})
+
+	Context("with multiple tabs", func() {
+		It("should handle multiple tabs correctly", func() {
+			multiTab := NewTab([]string{"Tab1", "Tab2", "Tab3", "Tab4"}, 0, 10, 20)
+
+			Expect(multiTab.titles).To(HaveLen(4))
+
+			// Check we can navigate through all tabs
+			for i := 0; i < len(multiTab.titles); i++ {
+				multiTab.SetActivePage(i)
+				Expect(multiTab.GetActivePage()).To(Equal(i))
+			}
+		})
+	})
+})


### PR DESCRIPTION
### Summary
This pull request introduces a new Tab component to the project, which allows users to navigate between the "Buildings" and "Upgrades" pages. The component visually highlights the active page and provides a clean and intuitive interface for switching between tabs.

### Changes
- Added `Tab` component in `ui/components/tab.go`.
- Created unit tests for the `Tab` component in `ui/components/tab_test.go` using Ginkgo.
- Integrated the `Tab` component into the `DefaultRenderer` to synchronize with the navigation system.

### Testing
- Verified that the `Tab` component initializes correctly with provided values.
- Ensured that the active page can be set and retrieved accurately.
- Confirmed that invalid page indices are ignored.
- Tested the drawing functionality to ensure no runtime errors occur.

### Notes
This feature enhances the user experience by providing a clear indication of the current page and simplifying navigation.

### Screenshots
N/A

### Related Issues
N/A